### PR TITLE
Only send the keypresses if it found the window

### DIFF
--- a/sendkey.sh
+++ b/sendkey.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 # Send a single key press to an open window with a given window title
+# It only sends the key event if it found the window.
 # Usage: sendkey.sh WINDOW-TITLE KEY
 #        WINDOW-TITLE can be a regex
 #        e.g. sendkey.sh 'Google Chrome' F5
 title=$1
 key=$2
 
+# Get the window ID using the 'wmctrl -l' command
 windowId=`wmctrl -l | awk "/$title/ {print "'$1}'`
+# If we didn't find the window, then exit with an error code.
+if [ ! $windowId ]; then
+    exit 1
+fi
+
+# Send the one key press
 xsendkey -window "$windowId" "$key"

--- a/sendkeys.sh
+++ b/sendkeys.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 # Send a series of key presses to an open window with a given window title
+# It only sends the key events if it found the window.
 # Usage: sendkeys.sh WINDOW-TITLE KEY
 #        WINDOW-TITLE can be a regex
 #        e.g. sendkeys.sh 'Terminal' 'start-server.sh'
 title=$1
 keys=$2
 
+# Get the window ID using the 'wmctrl -l' command
+windowId=`wmctrl -l | awk "/$title/ {print "'$1}'`
+# If we didn't find the window, then exit with an error code.
+if [ ! $windowId ]; then
+    exit 1
+fi
+
+# Send one character at a time
 for i in $(seq 0 $((${#keys} - 1))); do
   key=${keys:$i:1}
-  windowId=`wmctrl -l | awk "/$title/ {print "'$1}'`
 
   # Chars that we can't pass straight through to xsendkey
   # This list taken from X11/keysymdef.h


### PR DESCRIPTION
Hi, I modified the Bash scripts so they won't send keypresses if the window wasn't found, and will send an error status instead, to make it more useful for use with other scripts.